### PR TITLE
fix: tests and jest config

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -4,7 +4,7 @@ import AppStack, { rootNavigation } from './navigation';
 import { NavigationContainer } from '@react-navigation/native';
 
 const App = () => (
-    <NavigationContainer ref={ rootNavigation }>
+    <NavigationContainer ref={ rootNavigation.navigationRef }>
         <AppStack />
     </NavigationContainer>
 );

--- a/app/App.test.js
+++ b/app/App.test.js
@@ -3,20 +3,17 @@ import App from './App';
 import { shallow, mount } from 'enzyme';
 import { rootNavigation } from './navigation';
 
-describe('app tests', () => {
-    it('should render correctly', () => {
-        const tree = shallow(<App />);
+it('should render correctly', () => {
+    const tree = shallow(<App />);
 
-        expect(tree).toMatchSnapshot();
-    });
-
-    it('should have navigation ref', () => {
-        mount(<App />);
-
-        rootNavigation.navigate('Home');
-
-        expect(rootNavigation).toEqual(expect.objectContaining({
-            navigate: expect.any(Function),
-        }));
-    });
+    expect(tree).toMatchSnapshot();
 });
+
+it('should create navigation ref', () => {
+    mount(<App />);
+
+    expect(rootNavigation.navigationRef.current).toEqual(expect.objectContaining({
+        navigate: expect.any(Function),
+    }));
+});
+

--- a/app/__snapshots__/App.test.js.snap
+++ b/app/__snapshots__/App.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app tests should render correctly 1`] = `
+exports[`should render correctly 1`] = `
 <ForwardRef(NavigationContainer)>
   <AppStack />
 </ForwardRef(NavigationContainer)>

--- a/app/navigation/root/test/index.test.js
+++ b/app/navigation/root/test/index.test.js
@@ -1,0 +1,12 @@
+import { navigationRef, navigate } from '../';
+import createNavigation from '../../../../test-utils/react-navigation-prop';
+
+beforeEach(() => {
+    navigationRef.current = createNavigation();
+});
+
+it('should call navigate with the correct arguments', () => {
+    navigate('Foo', { foo: 'foo', bar: 'bar' });
+
+    expect(navigationRef.current.navigate).toHaveBeenNthCalledWith(1, 'Foo', { foo: 'foo', bar: 'bar' });
+});

--- a/app/navigation/test/__snapshots__/index.test.js.snap
+++ b/app/navigation/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`navigation tests should create navigation correctly 1`] = `
+exports[`should create navigation correctly 1`] = `
 <StackNavigator>
   <Screen
     component={[Function]}

--- a/app/navigation/test/index.test.js
+++ b/app/navigation/test/index.test.js
@@ -2,10 +2,9 @@ import React from 'react';
 import Navigation from '../';
 import { shallow } from 'enzyme';
 
-describe('navigation tests', () => {
-    it('should create navigation correctly', () => {
-        const tree = shallow(<Navigation />);
+it('should create navigation correctly', () => {
+    const tree = shallow(<Navigation />);
 
-        expect(tree).toMatchSnapshot();
-    });
+    expect(tree).toMatchSnapshot();
 });
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const esModules = ['react-native', 'react-navigation', '@react-navigation', '@re
 
 nativePresetConfig.preset = 'react-native';
 nativePresetConfig.setupFilesAfterEnv = [
-    './config/jest',
+    './jest.setup.js',
     './node_modules/react-native-gesture-handler/jestSetup.js',
 ];
 nativePresetConfig.transformIgnorePatterns = [

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,7 @@
-// https://enzymejs.github.io/enzyme/docs/guides/react-native.html
+// React Native configuration for Enzyme: https://enzymejs.github.io/enzyme/docs/guides/react-native.html
 const { JSDOM } = require('jsdom');
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://www.wook.pt' });
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
 const { window } = jsdom;
 
 function copyProps(src, target) {
@@ -16,6 +16,7 @@ global.document = window.document;
 global.navigator = {
     userAgent: 'node.js',
 };
+
 copyProps(window, global);
 
 const originalConsoleError = console.error;

--- a/test-utils/react-navigation-prop.js
+++ b/test-utils/react-navigation-prop.js
@@ -1,3 +1,5 @@
+// Reference documentation: https://reactnavigation.org/docs/navigation-prop/
+
 /* eslint-disable no-undef */
 export default () => ({
     state: { params: {} },


### PR DESCRIPTION
## Changes

- Tests are now asserting the root navigation ref is defined after App mounts.
- Added tests for root navigation.
- Removed all describe blocks.
- Removed `url` option from `JSDOM`'s constructor.
- **Proposal to discuss:** moved Jest setup from `./config/jest/index.js` to `./jest.setup.js`. Which approach should we favor now and in the future?