### PR TITLE
Fix safe area view for headers and screens (insets)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7805,7 +7805,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -8538,6 +8541,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -15551,6 +15560,21 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz",
       "integrity": "sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA=="
+    },
+    "react-native-safe-area-view": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-1.1.1.tgz",
+      "integrity": "sha512-bbLCtF+tqECyPWlgkWbIwx4vDPb0GEufx/ZGcSS4UljMcrpwluachDXoW9DBxhbMCc6k1V0ccqHWN7ntbRdERQ==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
     },
     "react-native-screens": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-native-localize": "^1.4.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^0.7.3",
+    "react-native-safe-area-view": "^1.1.1",
     "react-native-screens": "^2.3.0",
     "react-native-svg": "^12.0.3"
   },

--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import App from './App';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { mount } from 'enzyme';
+import localeConfig from '../../intl';
 import { rootNavigation } from '../navigation';
 import { LocaleProvider, ThemeProvider } from '../shared/modules';
-import localeConfig from '../../intl';
+import App from './App';
 
 it('should create navigation ref', () => {
     mount(<App />);
@@ -25,5 +26,11 @@ it('should render theme provider', () => {
     const tree = mount(<App />);
 
     expect(tree.find(ThemeProvider).exists()).toBe(true);
+});
+
+it('should render safe area provider', () => {
+    const tree = mount(<App />);
+
+    expect(tree.find(SafeAreaProvider).exists()).toBe(true);
 });
 

--- a/src/navigation/profile-stack/header/ProfileStackHeader.js
+++ b/src/navigation/profile-stack/header/ProfileStackHeader.js
@@ -2,21 +2,21 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 import { FormattedMessage } from 'react-intl';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import SafeAreaView from 'react-native-safe-area-view';
 import { Button, useTheme } from '../../../shared/modules';
 
-import buildStyles from './styles';
+import createStyles from './styles';
 
 const ProfileStackHeader = ({ navigation }) => {
     const { themeStyles } = useTheme();
-    const styles = buildStyles(themeStyles);
+    const styles = createStyles(themeStyles);
 
     const handlePress = useCallback(() => {
         navigation.pop();
     }, [navigation]);
 
     return (
-        <SafeAreaView style={ styles.safeAreaView }>
+        <SafeAreaView>
             <View style={ styles.header }>
                 <Button
                     accessibilityLabel="back button"

--- a/src/navigation/profile-stack/header/ProfileStackHeader.test.js
+++ b/src/navigation/profile-stack/header/ProfileStackHeader.test.js
@@ -1,13 +1,24 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import ProfileHeader from './';
+import SafeAreaView from 'react-native-safe-area-view';
 import { AppTree } from '../../../shared/test-utils/modules';
 import { createNavigationProp } from '../../../shared/test-utils/react-navigation';
+import ProfileHeader from './';
 
 const navigation = createNavigationProp();
 
 beforeEach(() => {
     navigation.navigate.mockClear();
+});
+
+it('should render a safe area view', () => {
+    const tree = mount(
+        <AppTree>
+            <ProfileHeader navigation={ navigation } />
+        </AppTree>,
+    );
+
+    expect(tree.find(SafeAreaView).exists()).toBe(true);
 });
 
 it('should pop the navigation stack when the back button is pressed', () => {

--- a/src/navigation/profile-stack/header/styles/index.js
+++ b/src/navigation/profile-stack/header/styles/index.js
@@ -1,11 +1,8 @@
 import { StyleSheet } from 'react-native';
 
 export default ({ typography, colors, layout }) => StyleSheet.create({
-    safeAreaView: {
-        height: 100,
-    },
     header: {
-        flex: 1,
+        height: 50,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-between',

--- a/src/screens/home/HomeScreen.js
+++ b/src/screens/home/HomeScreen.js
@@ -1,12 +1,12 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { FormattedMessage } from 'react-intl';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import SafeAreaView from 'react-native-safe-area-view';
 import { Button, useTheme, useLocale } from '../../shared/modules';
 import HomeHeader from './header';
 
-import buildStyles from './styles';
+import createStyles from './styles';
 
 const HomeScreen = ({ navigation }) => {
     navigation.setOptions({
@@ -14,9 +14,8 @@ const HomeScreen = ({ navigation }) => {
     });
 
     const { themeStyles } = useTheme();
-    const styles = useMemo(() => buildStyles(themeStyles), [themeStyles]);
+    const styles = useMemo(() => createStyles(themeStyles), [themeStyles]);
     const locale = useLocale();
-
     const handleNavigateToProfile = useCallback(() => {
         navigation.navigate('Profile', { screen: 'Profile2' });
     }, [navigation]);
@@ -25,28 +24,30 @@ const HomeScreen = ({ navigation }) => {
     }, [locale]);
 
     return (
-        <SafeAreaView style={ styles.container }>
-            <Text
-                accessibilityLabel="title"
-                style={ styles.text }>
-                <FormattedMessage id="home.title" />
-            </Text>
-            <Button
-                accessibilityLabel="navigate to profile button"
-                type="highlight"
-                title={ <FormattedMessage id="home.buttons.navigate-to-profile" /> }
-                style={ styles.button }
-                onPress={ handleNavigateToProfile }
-                textStyle={ styles.buttonText }
-                underlayColor={ themeStyles.colors.terciary } />
-            <Button
-                accessibilityLabel="switch language button"
-                type="highlight"
-                title={ <FormattedMessage id="home.buttons.switch-language" values={ { localeId: locale.id } } /> }
-                style={ styles.button }
-                onPress={ handleSwitchLanguage }
-                textStyle={ styles.buttonText }
-                underlayColor={ themeStyles.colors.terciary } />
+        <SafeAreaView style={ styles.safeArea }>
+            <View style={ styles.container }>
+                <Text
+                    accessibilityLabel="title"
+                    style={ styles.text }>
+                    <FormattedMessage id="home.title" />
+                </Text>
+                <Button
+                    accessibilityLabel="navigate to profile button"
+                    type="highlight"
+                    title={ <FormattedMessage id="home.buttons.navigate-to-profile" /> }
+                    style={ styles.button }
+                    onPress={ handleNavigateToProfile }
+                    textStyle={ styles.buttonText }
+                    underlayColor={ themeStyles.colors.terciary } />
+                <Button
+                    accessibilityLabel="switch language button"
+                    type="highlight"
+                    title={ <FormattedMessage id="home.buttons.switch-language" values={ { localeId: locale.id } } /> }
+                    style={ styles.button }
+                    onPress={ handleSwitchLanguage }
+                    textStyle={ styles.buttonText }
+                    underlayColor={ themeStyles.colors.terciary } />
+            </View>
         </SafeAreaView>
     );
 };

--- a/src/screens/home/HomeScreen.test.js
+++ b/src/screens/home/HomeScreen.test.js
@@ -1,14 +1,25 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import HomeHeader from './header';
-import HomeScreen from './HomeScreen';
+import SafeAreaView from 'react-native-safe-area-view';
 import { AppTree } from '../../shared/test-utils/modules';
 import { useLocale } from '../../shared/modules';
 import { createNavigationProp } from '../../shared/test-utils/react-navigation';
+import HomeHeader from './header';
+import HomeScreen from './HomeScreen';
 
 const navigation = createNavigationProp();
 
 beforeEach(jest.clearAllMocks);
+
+it('should render a safe area view', () => {
+    const tree = mount(
+        <AppTree>
+            <HomeScreen navigation={ navigation } />
+        </AppTree>,
+    );
+
+    expect(tree.find(SafeAreaView).exists()).toBe(true);
+});
 
 it('should render title', () => {
     const tree = mount(

--- a/src/screens/home/header/HomeHeader.js
+++ b/src/screens/home/header/HomeHeader.js
@@ -1,15 +1,18 @@
 import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import SafeAreaView from 'react-native-safe-area-view';
 import { Logo } from '../../../shared/media/icons';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
-import buildStyles from './styles';
+import createStyles from './styles';
 
 const HomeHeader = () => {
-    const styles = useMemo(() => buildStyles(), []);
+    const styles = useMemo(() => createStyles(), []);
 
     return (
-        <SafeAreaView style={ styles.header }>
-            <Logo width="120" height="50" />
+        <SafeAreaView>
+            <View style={ styles.container }>
+                <Logo width="120" height="50" />
+            </View>
         </SafeAreaView>
     );
 };

--- a/src/screens/home/header/HomeHeader.test.js
+++ b/src/screens/home/header/HomeHeader.test.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import SafeAreaView from 'react-native-safe-area-view';
 import { Logo } from '../../../shared/media/icons';
 import HomeHeader from '.';
 
 beforeEach(() => {
     jest.clearAllMocks();
+});
+
+it('should render a safe area view', () => {
+    const tree = mount(<HomeHeader />);
+
+    expect(tree.find(SafeAreaView).exists()).toBe(true);
 });
 
 it('should render the logo', () => {

--- a/src/screens/home/header/styles/index.js
+++ b/src/screens/home/header/styles/index.js
@@ -1,8 +1,8 @@
 import { StyleSheet } from 'react-native';
 
 export default () => StyleSheet.create({
-    header: {
-        height: 100,
+    container: {
+        height: 50,
         alignItems: 'center',
         justifyContent: 'center',
     },

--- a/src/screens/home/styles/index.js
+++ b/src/screens/home/styles/index.js
@@ -1,6 +1,9 @@
 import { StyleSheet } from 'react-native';
 
 export default ({ typography, colors, layout }) => StyleSheet.create({
+    safeArea: {
+        flex: 1,
+    },
     container: {
         flex: 1,
         alignItems: 'center',

--- a/src/screens/profile/1/ProfileScreen1.js
+++ b/src/screens/profile/1/ProfileScreen1.js
@@ -1,20 +1,22 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { FormattedMessage } from 'react-intl';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import SafeAreaView from 'react-native-safe-area-view';
 import { useTheme } from '../../../shared/modules';
 
-import buildStyles from '../styles';
+import createStyles from '../styles';
 
 const ProfileScreen1 = () => {
     const { themeStyles } = useTheme();
-    const styles = buildStyles(themeStyles);
+    const styles = createStyles(themeStyles);
 
     return (
-        <SafeAreaView style={ styles.container }>
-            <Text accessibilityLabel="title">
-                <FormattedMessage id="profile1.title" />
-            </Text>
+        <SafeAreaView style={ styles.safeArea }>
+            <View style={ styles.container }>
+                <Text accessibilityLabel="title">
+                    <FormattedMessage id="profile1.title" />
+                </Text>
+            </View>
         </SafeAreaView>
     );
 };

--- a/src/screens/profile/1/ProfileScreen1.test.js
+++ b/src/screens/profile/1/ProfileScreen1.test.js
@@ -1,7 +1,18 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import ProfileScreen1 from './ProfileScreen1';
+import SafeAreaView from 'react-native-safe-area-view';
 import { AppTree } from '../../../shared/test-utils/modules';
+import ProfileScreen1 from './ProfileScreen1';
+
+it('should render a safe area view', () => {
+    const tree = mount(
+        <AppTree>
+            <ProfileScreen1 />
+        </AppTree>,
+    );
+
+    expect(tree.find(SafeAreaView).exists()).toBe(true);
+});
 
 it('should render screen title', () => {
     const tree = mount(

--- a/src/screens/profile/2/ProfileScreen2.js
+++ b/src/screens/profile/2/ProfileScreen2.js
@@ -1,20 +1,22 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { FormattedMessage } from 'react-intl';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import SafeAreaView from 'react-native-safe-area-view';
 import { useTheme } from '../../../shared/modules';
 
-import buildStyles from '../styles';
+import createStyles from '../styles';
 
 const ProfileScreen2 = () => {
     const { themeStyles } = useTheme();
-    const styles = buildStyles(themeStyles);
+    const styles = createStyles(themeStyles);
 
     return (
-        <SafeAreaView style={ styles.container }>
-            <Text accessibilityLabel="title">
-                <FormattedMessage id="profile2.title" />
-            </Text>
+        <SafeAreaView style={ styles.safeArea }>
+            <View style={ styles.container }>
+                <Text accessibilityLabel="title">
+                    <FormattedMessage id="profile2.title" />
+                </Text>
+            </View>
         </SafeAreaView>
     );
 };

--- a/src/screens/profile/2/ProfileScreen2.test.js
+++ b/src/screens/profile/2/ProfileScreen2.test.js
@@ -1,7 +1,18 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import ProfileScreen2 from './ProfileScreen2';
+import SafeAreaView from 'react-native-safe-area-view';
 import { AppTree } from '../../../shared/test-utils/modules';
+import ProfileScreen2 from './ProfileScreen2';
+
+it('should render a safe area view', () => {
+    const tree = mount(
+        <AppTree>
+            <ProfileScreen2 />
+        </AppTree>,
+    );
+
+    expect(tree.find(SafeAreaView).exists()).toBe(true);
+});
 
 it('should render screen title', () => {
     const tree = mount(

--- a/src/screens/profile/styles/index.js
+++ b/src/screens/profile/styles/index.js
@@ -1,6 +1,9 @@
 import { StyleSheet } from 'react-native';
 
 export default () => StyleSheet.create({
+    safeArea: {
+        flex: 1,
+    },
     container: {
         flex: 1,
         alignItems: 'center',

--- a/src/shared/modules/index.test.js
+++ b/src/shared/modules/index.test.js
@@ -8,4 +8,8 @@ it('should export all named modules', () => {
     expect(modules).toHaveProperty('LocaleConsumer');
     expect(modules).toHaveProperty('useLocale');
     expect(modules).toHaveProperty('withLocale');
+    expect(modules).toHaveProperty('AppConfigProvider');
+    expect(modules).toHaveProperty('AppConfigConsumer');
+    expect(modules).toHaveProperty('useAppConfig');
+    expect(modules).toHaveProperty('withAppConfig');
 });


### PR DESCRIPTION
We shouldn't use `SafeAreaView` from `react-native-safe-area-context` because it always applies a bottom padding in header components and a top one in screen components. This behavior is not desired. We're now using `SafeAreaView` from `react-native-safe-area-view` instead which uses `react-native-safe-area-context` to get the devices' insets and apply paddings in smarter ways. `SafeAreaView` will only apply padding to compensate for insets when:

- `SafeAreaView` intersects a safe area
- `SafeAreaView` itself already has a padding equal or greater than the insets' padding