### PR TITLE
chore: update documentation page about testing

### DIFF
--- a/docusaurus/docs/what-is-included/jest-enzyme.md
+++ b/docusaurus/docs/what-is-included/jest-enzyme.md
@@ -1,9 +1,0 @@
----
-id: testing-with-jest-enzyme
-title: Testing with Jest and Enzyme
-sidebar_label: Testing with Jest and Enzyme
----
-
-For testing, this boilerplate is configured to use [**Jest**](https://jestjs.io/) and [**Enzyme**](https://github.com/enzymejs/enzyme), providing strong options for testing varied types of code.
-
-You can find more details about our implementation of Jest in its configuration file, `jest.config.js`, which uses our own [`@moxy/jest-config`](https://github.com/moxystudio/jest-config).

--- a/docusaurus/docs/what-is-included/jest-react-native-testing-library.md
+++ b/docusaurus/docs/what-is-included/jest-react-native-testing-library.md
@@ -1,0 +1,9 @@
+---
+id: testing-with-jest-native-testing-library
+title: Testing with Jest and Native Testing Library
+sidebar_label: Testing with Jest & NTL
+---
+
+For testing, this boilerplate is configured to use [**Jest**](https://jestjs.io/) and [**Native Testing Library**](https://github.com/testing-library/native-testing-library), providing strong options for testing varied types of code.
+
+You can find more details about our implementation of Jest in its configuration file, `jest.config.js`, which uses our own [`@moxy/jest-config`](https://github.com/moxystudio/jest-config).

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -27,7 +27,7 @@ module.exports = {
                 'what-is-included/react-navigation',
                 'what-is-included/eslint',
                 'what-is-included/internationalization',
-                'what-is-included/testing-with-jest-enzyme',
+                'what-is-included/testing-with-jest-native-testing-library',
                 'what-is-included/environment-variables',
             ],
         },


### PR DESCRIPTION
This PR will update the documentation's page about testing to reflect the fact we are now using [Native Testing Library](https://github.com/testing-library/native-testing-library) instead of [Enzyme](https://github.com/enzymejs/enzyme).